### PR TITLE
Handle messages in a fiber

### DIFF
--- a/listen.php
+++ b/listen.php
@@ -78,7 +78,7 @@ class ConsumerRouter
 			$channel = $this->client->channel();
 			$channel->qos(0, $prefetchCount);
 			$publishChannel = null;
-			$channel->consume(function (BunnyMessage $bunnyMessage, Channel $channel) use (&$publishChannel, $queueName): void {
+			$channel->consume(async(function (BunnyMessage $bunnyMessage, Channel $channel) use (&$publishChannel, $queueName): void {
 
 				try {
 					try {
@@ -121,7 +121,7 @@ class ConsumerRouter
 					$this->stopConsumer();
 					throw $e;
 				}
-			}, $queueName);
+			}), $queueName);
 
 			$this->writeln(sprintf('Listening on queue %s', $queueName));
 			$this->writeln('Waiting for messages...');


### PR DESCRIPTION
As an addition to #1, by running all messages consumer in a fiber as well the awaits in there don't cause additional weirdness. 

Optionally consider using https://reactphp.org/promise-timer/#sleep as `await(sleep(1));` to no block anything.